### PR TITLE
Lower token threshold for large JSON/YAML files from 5000 to 2000

### DIFF
--- a/src/fs_mcp/server.py
+++ b/src/fs_mcp/server.py
@@ -235,7 +235,7 @@ def read_files(files: List[FileReadRequest], large_file_passthrough: bool = Fals
                 if file_ext in ['.json', '.yaml', '.yml']:
                     file_size = os.path.getsize(path_obj)
                     tokens = file_size / 4  # Approximate token count
-                    if tokens > 5000:
+                    if tokens > 2000:
                         query_tool = "n/a ignore this line"
                         file_type = "n/a ignore this line"
                         if file_ext in ['.json','.yaml', '.yml']:


### PR DESCRIPTION
## Summary
Reduced the token threshold for identifying large JSON and YAML files from 5000 to 2000 tokens, making the system more conservative in classifying files as "large" for passthrough handling.

## Changes
- Lowered the token count threshold in `read_files()` function from 5000 to 2000 tokens
- This affects the logic that determines when to apply large file passthrough behavior for `.json`, `.yaml`, and `.yml` files

## Details
The threshold is used to approximate file size in tokens (calculated as file_size / 4). Files exceeding this threshold are now flagged earlier, which may impact:
- Memory usage during file processing
- Performance characteristics for moderately-sized configuration files
- The behavior of the `large_file_passthrough` feature

This change makes the system treat files as "large" more aggressively, potentially improving performance and resource management for typical use cases.

https://claude.ai/code/session_01F2yqdMsh1TjjtkUwSEwa3p