### PR TITLE
Add machine-generated directory filtering to grep and tree tools

### DIFF
--- a/internal/tools/common.go
+++ b/internal/tools/common.go
@@ -11,6 +11,59 @@ type Config struct {
 	ManagedBin string
 }
 
+// ignoredDirNames are directory basenames universally treated as machine-
+// generated noise: dependency caches, build outputs, language venvs, VCS
+// internals. Matched by basename anywhere in the walk, so the rule is
+// repo-agnostic and safe across roots that contain multiple sibling repos —
+// no risk of one repo's ignore pattern hiding another repo's source.
+//
+// Borderline names that legitimate source code sometimes uses (bin, obj,
+// env, lib, .vscode, .idea, .github) are intentionally excluded. The
+// `include_ignored: true` flag on grep + directory_tree disables this
+// filter entirely when an agent genuinely needs to traverse vendored
+// packages.
+var ignoredDirNames = map[string]struct{}{
+	"node_modules":  {},
+	".git":          {},
+	".svn":          {},
+	".hg":           {},
+	"dist":          {},
+	"build":         {},
+	"target":        {},
+	".venv":         {},
+	"venv":          {},
+	"__pycache__":   {},
+	".pytest_cache": {},
+	".mypy_cache":   {},
+	".ruff_cache":   {},
+	".tox":          {},
+	".next":         {},
+	".nuxt":         {},
+	".cache":        {},
+	".terraform":    {},
+	".gradle":       {},
+	"coverage":      {},
+	".nyc_output":   {},
+}
+
+// isIgnoredDirName reports whether the basename matches a universally
+// machine-generated directory. Callers must already have established that
+// the entry is a directory.
+func isIgnoredDirName(name string) bool {
+	_, ok := ignoredDirNames[name]
+	return ok
+}
+
+// ignoredDirGlobs returns ripgrep --glob exclusions matching the same
+// denylist. Used by grep when include_ignored is false.
+func ignoredDirGlobs() []string {
+	out := make([]string, 0, len(ignoredDirNames)*2)
+	for name := range ignoredDirNames {
+		out = append(out, "-g", "!"+name)
+	}
+	return out
+}
+
 func (c Config) ResolvePath(p string) (string, error) {
 	if p == "" || p == "." {
 		return c.Root, nil

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -37,6 +37,7 @@ type GrepInput struct {
 	TimeoutSec      int      `json:"timeout_sec,omitempty" jsonschema:"Timeout in seconds. Default 30."`
 	SectionPatterns []string `json:"section_patterns,omitempty" jsonschema:"Regexes used to compute section_end_hint per match (first line at or after the match that matches any pattern). Pass [] to disable. Default covers Go/Python/JS-TS/Rust/C-family boundaries."`
 	NoSectionHint   bool     `json:"no_section_hint,omitempty" jsonschema:"Disable section_end_hint computation entirely."`
+	IncludeIgnored  bool     `json:"include_ignored,omitempty" jsonschema:"Search inside machine-generated dirs (node_modules, dist, build, target, .venv, __pycache__, .git, .terraform, etc.) AND any .gitignore-excluded paths and hidden files. Off by default — keeps results focused on real source. Turn on when you need to inspect vendored deps or build output."`
 }
 
 type GrepMatch struct {
@@ -80,6 +81,18 @@ func grepTool(cfg Config) func(context.Context, *mcp.CallToolRequest, GrepInput)
 			"--one-file-system",
 			"--max-filesize=50M",
 			"--threads=2",
+		}
+		if in.IncludeIgnored {
+			// Bypass ripgrep's .gitignore + hidden-file defaults. Skip the
+			// static denylist too — caller has explicitly asked for the
+			// noisy paths.
+			args = append(args, "--no-ignore", "--hidden")
+		} else {
+			// Layer the static denylist on top of ripgrep's gitignore
+			// handling. Basename-only globs are safe across multi-repo
+			// roots (matches "node_modules" anywhere, regardless of which
+			// sibling repo it sits in).
+			args = append(args, ignoredDirGlobs()...)
 		}
 		if path == "/" || isNetworkFS(path) {
 			maxDepth := in.MaxDepth
@@ -212,6 +225,6 @@ func parseRgJSON(stdout string, out *GrepOutput) {
 func RegisterGrep(s *mcp.Server, cfg Config) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "grep",
-		Description: "Recursive regex search via ripgrep. Symlink-safe at / and network FS (auto --max-depth=4, --no-follow, --one-file-system, --max-filesize=50M, --threads=2). Each match includes section_end_hint: the first line at or after the match where a section boundary (func/class/def/type/etc.) begins — use it as end_line for a targeted read_files follow-up.",
+		Description: "Recursive regex search via ripgrep. Symlink-safe at / and network FS (auto --max-depth=4, --no-follow, --one-file-system, --max-filesize=50M, --threads=2). Skips machine-generated dirs (node_modules, dist, build, target, .venv, __pycache__, .git, .terraform, etc.) and honors .gitignore by default; set include_ignored=true to scan vendored deps and build output. Each match includes section_end_hint: the first line at or after the match where a section boundary (func/class/def/type/etc.) begins — use it as end_line for a targeted read_files follow-up.",
 	}, grepTool(cfg))
 }

--- a/internal/tools/tree.go
+++ b/internal/tools/tree.go
@@ -9,10 +9,11 @@ import (
 )
 
 type DirectoryTreeInput struct {
-	Path      string `json:"path,omitempty" jsonschema:"Directory to walk. Defaults to portal root."`
-	MaxDepth  int    `json:"max_depth,omitempty" jsonschema:"Max recursion depth. Default 3. Auto-capped to 4 when root is '/' or a network FS."`
-	ShowSizes bool   `json:"show_sizes,omitempty" jsonschema:"Include size and mtime per entry."`
-	IncludeFiles bool `json:"include_files,omitempty" jsonschema:"Include files in output (default: only dirs). Default true."`
+	Path           string `json:"path,omitempty" jsonschema:"Directory to walk. Defaults to portal root."`
+	MaxDepth       int    `json:"max_depth,omitempty" jsonschema:"Max recursion depth. Default 3. Auto-capped to 4 when root is '/' or a network FS."`
+	ShowSizes      bool   `json:"show_sizes,omitempty" jsonschema:"Include size and mtime per entry."`
+	IncludeFiles   bool   `json:"include_files,omitempty" jsonschema:"Include files in output (default: only dirs). Default true."`
+	IncludeIgnored bool   `json:"include_ignored,omitempty" jsonschema:"Descend into machine-generated dirs (node_modules, dist, build, target, .venv, __pycache__, .git, .terraform, etc.). Off by default — cuts noise when exploring a project root, especially a multi-repo workspace. Turn on when you need to walk vendored deps or build output."`
 }
 
 type TreeEntry struct {
@@ -75,6 +76,12 @@ func directoryTree(cfg Config) func(context.Context, *mcp.CallToolRequest, Direc
 				}
 				return nil
 			}
+			// Skip universally machine-generated dirs unless caller opted in.
+			// Basename match is repo-agnostic — safe when root contains
+			// multiple sibling repos.
+			if !in.IncludeIgnored && d.IsDir() && depth > 0 && isIgnoredDirName(d.Name()) {
+				return fs.SkipDir
+			}
 			entry := TreeEntry{Path: p, Depth: depth}
 			if d.IsDir() {
 				entry.Type = "dir"
@@ -102,6 +109,6 @@ func directoryTree(cfg Config) func(context.Context, *mcp.CallToolRequest, Direc
 func RegisterDirectoryTree(s *mcp.Server, cfg Config) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "directory_tree",
-		Description: "Recursive directory listing with optional size/mtime. Depth auto-capped at 4 for / and network FS.",
+		Description: "Recursive directory listing with optional size/mtime. Skips machine-generated dirs (node_modules, dist, build, target, .venv, __pycache__, .git, .terraform, etc.) by default — set include_ignored=true to walk them. Depth auto-capped at 4 for / and network FS.",
 	}, directoryTree(cfg))
 }


### PR DESCRIPTION
## Summary
This PR adds intelligent filtering of machine-generated directories (node_modules, dist, build, .venv, __pycache__, .git, .terraform, etc.) to the `grep` and `directory_tree` tools. Both tools now skip these directories by default to reduce noise when exploring projects, with an `include_ignored` flag to opt-in to traversing them when needed.

## Key Changes

- **New common utilities** (`internal/tools/common.go`):
  - Added `ignoredDirNames` map defining universally machine-generated directory basenames
  - Added `isIgnoredDirName()` function to check if a directory should be filtered
  - Added `ignoredDirGlobs()` function to generate ripgrep `--glob` exclusion arguments

- **Directory tree tool** (`internal/tools/tree.go`):
  - Added `IncludeIgnored` boolean field to `DirectoryTreeInput` struct
  - Implemented directory filtering logic that skips ignored directories when `IncludeIgnored` is false
  - Updated tool description to document the filtering behavior and the new flag
  - Aligned struct field formatting for consistency

- **Grep tool** (`internal/tools/grep.go`):
  - Added `IncludeIgnored` boolean field to `GrepInput` struct
  - Implemented conditional ripgrep argument handling:
    - When `IncludeIgnored=true`: passes `--no-ignore --hidden` to bypass gitignore and hidden file defaults
    - When `IncludeIgnored=false`: applies the static denylist via `--glob` exclusions on top of ripgrep's gitignore handling
  - Updated tool description to document the filtering behavior and the new flag

## Implementation Details

- The filtering uses basename-only matching, making it safe for multi-repo workspaces where multiple sibling repositories exist under a single root
- The static denylist is intentionally conservative, excluding borderline names (bin, obj, env, lib, .vscode, .idea, .github) that legitimate source code sometimes uses
- Both tools maintain backward compatibility with existing behavior while providing the new filtering by default

https://claude.ai/code/session_01B96m3FXitwQzoqsw1qm9yJ